### PR TITLE
Persistence of Plain Old CLR Interfaces (POCI)

### DIFF
--- a/Lex.Db.Tests/Net4/Lex.Db.Tests.Net4.csproj
+++ b/Lex.Db.Tests/Net4/Lex.Db.Tests.Net4.csproj
@@ -40,6 +40,9 @@
     <Reference Include="Microsoft.CompilerServices.AsyncTargetingPack.Net4">
       <HintPath>..\..\packages\Microsoft.CompilerServices.AsyncTargetingPack.1.0.0\lib\net40\Microsoft.CompilerServices.AsyncTargetingPack.Net4.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -54,11 +57,7 @@
         <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
   <ItemGroup>
     <Compile Include="..\UnitTests\DbTests.cs">
@@ -70,6 +69,7 @@
     <Compile Include="..\UnitTests\Stopwatch.cs">
       <Link>UnitTests\Stopwatch.cs</Link>
     </Compile>
+    <Compile Include="UnitTests\InterfaceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Lex.Db.Tests/Net4/UnitTests/InterfaceTests.cs
+++ b/Lex.Db.Tests/Net4/UnitTests/InterfaceTests.cs
@@ -1,0 +1,437 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Lex.Db.UnitTests
+{
+    [TestClass]
+    public class InterfaceTests
+    {
+        public TestContext TestContext { get; set; }
+
+        DbInstance db;
+        DbTable<IMyData> table;
+
+        DbInstance Prepare()
+        {
+            var db = new DbInstance("MyDatabase");
+            db.Map<IMyData, MyData>().Automap(i => i.Id, true);
+            db.Initialize();
+            return db;
+        }
+
+        [TestInitialize]
+        public void PurgeDb()
+        {
+            using (var i = Prepare())
+                i.Purge();
+
+            db = Prepare();
+            table = db.Table<IMyData>();
+        }
+
+        [TestCleanup]
+        public void CleanUp()
+        {
+            db.Purge();
+            db.Dispose();
+        }
+
+        [TestMethod]
+        public void OpenDb()
+        {
+            var db = new DbInstance("My Database");
+            db.Initialize();
+        }
+
+        [TestMethod]
+        public void Indexing()
+        {
+            var db = new DbInstance(@"My Database\Indexing");
+
+            db.Map<IMyData, MyData>().Automap(i => i.Id, true)
+              .WithIndex("LastName", i => i.Name, StringComparer.CurrentCulture)
+              .WithIndex("LastNameText", i => i.Name, StringComparer.CurrentCultureIgnoreCase);
+            db.Initialize();
+
+            var table = db.Table<IMyData>();
+            table.Purge();
+
+            db.BulkWrite(() =>
+            {
+                for (var s = 0; s < 100; s++)
+                    for (var i = 0; i < 10; i++)
+                        table.Save(new MyData { Name = "Test" + i });
+
+                for (var s = 0; s < 100; s++)
+                    for (var i = 0; i < 10; i++)
+                        table.Save(new MyData { Name = "TeST" + i });
+            });
+
+            var list1 = table.LoadAll("LastName", "Test5");
+            var list2 = table.LoadAll("LastNameText", "TEst5");
+
+            Assert.AreEqual(list1.Count, 100);
+            Assert.AreEqual(list2.Count, 200);
+        }
+
+        [TestMethod]
+        public void LoadData()
+        {
+            var table = db.Table<IMyData>();
+            var items = table.LoadAll();
+        }
+
+        [TestMethod]
+        public void SaveData()
+        {
+            var swatch = DateTime.Now;
+
+            db.BulkWrite(() =>
+            {
+                table.Purge();
+                var key = 1;
+                var newObj = new MyData { Id = key, Name = "test" };
+                table.Save(newObj);
+
+                var obj = table.LoadByKey(key);
+
+                Assert.AreEqual(newObj.Name, obj.Name);
+#if !NETFX_CORE
+                TestContext.WriteLine("Completed: " + (DateTime.Now - swatch).TotalMilliseconds);
+#endif
+            });
+        }
+
+        [TestMethod]
+        public void SaveDataBulk()
+        {
+            db.BulkWrite(() =>
+            {
+                var cnt = DoSaveDataBulk();
+
+                Assert.AreEqual(table.Count(), cnt);
+            });
+        }
+
+        int DoSaveDataBulk()
+        {
+            table.Purge();
+            var list = new List<MyData>();
+            var cnt = 50000;
+            for (int i = 0; i < cnt; i++)
+                list.Add(new MyData { Name = "test " + i, LastName = "My Some Last Name " + i });
+
+            table.Save(list);
+            return cnt;
+        }
+
+        [TestMethod]
+        public void LoadDataBulk()
+        {
+            db.BulkWrite(() =>
+            {
+                var cnt = DoSaveDataBulk();
+                var load = table.LoadAll();
+                Assert.AreEqual(cnt, load.Count);
+            });
+        }
+
+        [TestMethod]
+        public void Compact()
+        {
+            table.Compact();
+        }
+
+
+        [TestMethod]
+        public void RountripNulls()
+        {
+            var obj = new MyData();
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.BoolNField, newObj.BoolNField);
+            Assert.AreEqual(obj.IntNField, newObj.IntNField);
+            Assert.AreEqual(obj.LongNField, newObj.LongNField);
+            Assert.AreEqual(obj.DoubleNField, newObj.DoubleNField);
+            Assert.AreEqual(obj.FloatNField, newObj.FloatNField);
+            Assert.AreEqual(obj.DecimalNField, newObj.DecimalNField);
+            Assert.AreEqual(obj.TimeSpanNField, newObj.TimeSpanNField);
+            Assert.AreEqual(obj.DateTimeNField, newObj.DateTimeNField);
+            Assert.AreEqual(obj.DateTimeOffsetNField, newObj.DateTimeOffsetNField);
+            Assert.AreEqual(obj.GuidNField, newObj.GuidNField);
+            Assert.AreEqual(obj.EnumNField, newObj.EnumNField);
+            Assert.AreEqual(obj.Name, newObj.Name);
+
+        }
+
+        #region Bool Rountrip Tests
+
+        [TestMethod]
+        public void RountripBool1()
+        {
+            var obj = new MyData { BoolField = true, BoolNField = false };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.BoolField, newObj.BoolField);
+            Assert.AreEqual(obj.BoolNField, newObj.BoolNField);
+        }
+
+        [TestMethod]
+        public void RountripBool2()
+        {
+            var obj = new MyData { BoolField = false, BoolNField = true };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.BoolField, newObj.BoolField);
+            Assert.AreEqual(obj.BoolNField, newObj.BoolNField);
+        }
+
+        #endregion
+
+        #region Int Rountrip Tests
+
+        [TestMethod]
+        public void RountripInt1()
+        {
+            var obj = new MyData { IntField = int.MaxValue, IntNField = int.MinValue };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.IntField, newObj.IntField);
+            Assert.AreEqual(obj.IntNField, newObj.IntNField);
+        }
+
+        [TestMethod]
+        public void RountripInt2()
+        {
+            var obj = new MyData { IntField = int.MinValue, IntNField = int.MaxValue };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.IntField, newObj.IntField);
+            Assert.AreEqual(obj.IntNField, newObj.IntNField);
+        }
+
+        #endregion
+
+        #region Long Rountrip Tests
+
+        [TestMethod]
+        public void RountripLong1()
+        {
+            var obj = new MyData { LongField = long.MaxValue, LongNField = long.MinValue };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.LongField, newObj.LongField);
+            Assert.AreEqual(obj.LongNField, newObj.LongNField);
+        }
+
+        [TestMethod]
+        public void RountripLong2()
+        {
+            var obj = new MyData { LongField = long.MinValue, LongNField = long.MaxValue };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.LongField, newObj.LongField);
+            Assert.AreEqual(obj.LongNField, newObj.LongNField);
+        }
+
+        #endregion
+
+        #region Float Rountrip Tests
+
+        [TestMethod]
+        public void RountripFloat1()
+        {
+            var obj = new MyData { FloatField = (float)Math.PI, FloatNField = (float)-Math.PI };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.FloatField, newObj.FloatField);
+            Assert.AreEqual(obj.FloatNField, newObj.FloatNField);
+        }
+
+        #endregion
+
+        #region Double Rountrip Tests
+
+        [TestMethod]
+        public void RountripDouble1()
+        {
+            var obj = new MyData { DoubleField = Math.PI, DoubleNField = -Math.PI };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.DoubleField, newObj.DoubleField);
+            Assert.AreEqual(obj.DoubleNField, newObj.DoubleNField);
+        }
+
+        #endregion
+
+        #region Decimal Rountrip Tests
+
+        [TestMethod]
+        public void RountripDecimal1()
+        {
+            var obj = new MyData { DecimalField = (decimal)Math.PI, DecimalNField = (decimal)-Math.PI };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.DecimalField, newObj.DecimalField);
+            Assert.AreEqual(obj.DecimalNField, newObj.DecimalNField);
+        }
+
+        #endregion
+
+        #region String Rountrip Tests
+
+        [TestMethod]
+        public void RountripString1()
+        {
+            var obj = new MyData { Name = "Test ABC" };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.Name, newObj.Name);
+        }
+
+        #endregion
+
+        #region Guid Rountrip Tests
+
+        [TestMethod]
+        public void RountripGuid1()
+        {
+            var obj = new MyData { GuidField = Guid.NewGuid(), GuidNField = Guid.NewGuid() };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.GuidField, newObj.GuidField);
+            Assert.AreEqual(obj.GuidNField, newObj.GuidNField);
+        }
+
+        #endregion
+
+        #region Enum Rountrip Tests
+
+        [TestMethod]
+        public void RountripEnum1()
+        {
+            var obj = new MyData { EnumField = TestEnum.EnumValue1, EnumNField = TestEnum.EnumValue2 };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.EnumField, newObj.EnumField);
+            Assert.AreEqual(obj.EnumNField, newObj.EnumNField);
+        }
+
+        #endregion
+
+        #region TimeSpan Rountrip Tests
+
+        [TestMethod]
+        public void RountripTimeSpan1()
+        {
+            var obj = new MyData { TimeSpanField = new TimeSpan(1, 2, 3), TimeSpanNField = new TimeSpan(2, 3, 4) };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.TimeSpanField, newObj.TimeSpanField);
+            Assert.AreEqual(obj.TimeSpanNField, newObj.TimeSpanNField);
+        }
+
+        #endregion
+
+        #region DateTime Rountrip Tests
+
+        [TestMethod]
+        public void RountripDateTime1()
+        {
+            var obj = new MyData { DateTimeField = new DateTime(1, 2, 3, 4, 5, 6), DateTimeNField = new DateTime(2, 3, 4, 5, 6, 7) };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.DateTimeField, newObj.DateTimeField);
+            Assert.AreEqual(obj.DateTimeNField, newObj.DateTimeNField);
+        }
+
+        #endregion
+
+        #region DateTimeOffset Rountrip Tests
+
+        [TestMethod]
+        public void RountripDateTimeOffset1()
+        {
+            var obj = new MyData { DateTimeOffsetField = new DateTimeOffset(1, 2, 3, 4, 5, 6, TimeSpan.FromMinutes(60)), DateTimeOffsetNField = new DateTimeOffset(2, 3, 4, 5, 6, 7, TimeSpan.FromMinutes(120)) };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.AreEqual(obj.DateTimeOffsetField, newObj.DateTimeOffsetField);
+            Assert.AreEqual(obj.DateTimeOffsetNField, newObj.DateTimeOffsetNField);
+        }
+
+        #endregion
+
+        #region DateTime Rountrip Tests
+
+        [TestMethod]
+        public void RountripList1()
+        {
+            var obj = new MyData
+            {
+                ListField = { 1, 2, 3, 4, 5 },
+                DictField = { { "test1", 111 }, { "test2", 222 }, { "test3", 333 } }
+            };
+
+            table.Save(obj);
+
+            var newObj = table.LoadByKey(obj.Id);
+
+            Assert.IsTrue(obj.ListField.SequenceEqual(newObj.ListField));
+            Assert.IsTrue(obj.DictField.Keys.SequenceEqual(newObj.DictField.Keys));
+            Assert.IsTrue(obj.DictField.Values.SequenceEqual(newObj.DictField.Values));
+        }
+
+        #endregion
+    }
+}

--- a/Lex.Db.Tests/UnitTests/Entities.cs
+++ b/Lex.Db.Tests/UnitTests/Entities.cs
@@ -3,7 +3,50 @@ using System.Collections.Generic;
 
 namespace Lex.Db
 {
-  public class MyData
+  public interface IMyData
+  {
+      int Id { get; set; }
+      string Name { get; set; }
+      string LastName { get; set; }
+
+      int IntField { get; set; }
+      int? IntNField { get; set; }
+
+      long LongField { get; set; }
+      long? LongNField { get; set; }
+
+      double DoubleField { get; set; }
+      double? DoubleNField { get; set; }
+
+      decimal DecimalField { get; set; }
+      decimal? DecimalNField { get; set; }
+
+      float FloatField { get; set; }
+      float? FloatNField { get; set; }
+
+      bool BoolField { get; set; }
+      bool? BoolNField { get; set; }
+
+      DateTime DateTimeField { get; set; }
+      DateTime? DateTimeNField { get; set; }
+
+      DateTimeOffset DateTimeOffsetField { get; set; }
+      DateTimeOffset? DateTimeOffsetNField { get; set; }
+
+      TimeSpan TimeSpanField { get; set; }
+      TimeSpan? TimeSpanNField { get; set; }
+
+      Guid GuidField { get; set; }
+      Guid? GuidNField { get; set; }
+
+      List<int> ListField { get; set; }
+      Dictionary<string, int> DictField { get; set; }
+
+      TestEnum EnumField { get; set; }
+      TestEnum? EnumNField { get; set; }
+  }
+
+  public class MyData : IMyData
   {
     public int Id { get; set; }
     public string Name { get; set; }

--- a/Lex.Db/Core/CtorOfT.cs
+++ b/Lex.Db/Core/CtorOfT.cs
@@ -18,4 +18,17 @@ namespace Lex.Db
 #endif
     public static readonly Func<T> New = Expression.Lambda<Func<T>>(Expression.New(typeof(T))).Compile();
   }
+
+  static class Ctor<TInterface, TType> where TType : TInterface
+  {
+#if NLOG
+    static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    static Ctor()
+    {
+      Log.Trace("Constructor for {0} created", typeof(T).Name);
+    }
+#endif
+      public static readonly Func<TInterface> New = Expression.Lambda<Func<TInterface>>(Expression.New(typeof(TType))).Compile();
+  }
 }

--- a/Lex.Db/Db/DbInstance.cs
+++ b/Lex.Db/Db/DbInstance.cs
@@ -132,6 +132,39 @@ namespace Lex.Db
     }
 
     /// <summary>
+    /// Maps the specified interface type in the dataase, using the type as concrete implementation where necessary
+    /// and provides mapping infrastructure
+    /// </summary>
+    /// <typeparam name="TInterface"></typeparam>
+    /// <typeparam name="TType"></typeparam>
+    /// <returns></returns>
+    public InterfaceMap<TInterface, TType> Map<TInterface, TType>() where TType : class, TInterface, new()
+    {
+        CheckNotSealed();
+
+        lock (_maps)
+        {
+            TypeMap result;
+
+            if (_maps.TryGetValue(typeof(TInterface), out result))
+            {
+                InterfaceMap<TInterface, TType> interfaceMap = (result as InterfaceMap<TInterface, TType>);
+
+                if (interfaceMap != null)
+                {
+                    return interfaceMap;
+                }
+            }
+
+            InterfaceMap<TInterface, TType> map = new InterfaceMap<TInterface, TType>(this);
+
+            _maps[typeof(TInterface)] = map;
+
+            return map;
+        }
+    }
+
+    /// <summary>
     /// Provides database table infrastructure to read/write/query entities
     /// </summary>
     /// <typeparam name="T"></typeparam>

--- a/Lex.Db/Indexing/DataIndex.cs
+++ b/Lex.Db/Indexing/DataIndex.cs
@@ -27,7 +27,7 @@ namespace Lex.Db.Indexing
   }
 
   [DebuggerDisplay("{_name} ({ToString()}) : {Count}")]
-  internal class DataIndex<T, K> : IDataIndex<T, K>, IEnumerable<DataNode<K>>, ICleanup where T : class
+  internal class DataIndex<T, K> : IDataIndex<T, K>, IEnumerable<DataNode<K>>, ICleanup
   {
     readonly string _name;
     readonly Func<T, K> _getter;

--- a/Lex.Db/Lex.Db.Net4.csproj
+++ b/Lex.Db/Lex.Db.Net4.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Indexing\Lazies.cs" />
     <Compile Include="Indexing\RedBlackTree.cs" />
     <Compile Include="Mapping\DataMap.cs" />
+    <Compile Include="Mapping\InterfaceMap.cs" />
     <Compile Include="Mapping\MemberMap.cs" />
     <Compile Include="Mapping\Metadata.cs" />
     <Compile Include="Mapping\TypeMap.cs" />

--- a/Lex.Db/Mapping/InterfaceMap.cs
+++ b/Lex.Db/Mapping/InterfaceMap.cs
@@ -1,0 +1,355 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Xml.Serialization;
+using Lex.Db.Serialization;
+
+namespace Lex.Db
+{
+    /// <summary>
+    /// Represents a <see cref="TypeMap{T}"/> which supports writing from an interface
+    /// </summary>
+    /// <typeparam name="TInterface"></typeparam>
+    /// <typeparam name="TType"></typeparam>
+    [DebuggerDisplay("{Name}")]
+    public sealed class InterfaceMap<TInterface, TType> : TypeMap where TType : class, TInterface
+    {
+        private DbInstance _db;
+        private DbTable<TInterface> _table;
+        private MemberInfo _key;
+
+        internal InterfaceMap(DbInstance db)
+        {
+            _db = db;
+            Reset();
+        }
+
+        internal override void Clear()
+        {
+            _table = new DbTable<TInterface, TType>(_db, Ctor<TInterface, TType>.New);
+        }
+
+        /// <summary>
+        /// Indicates name of the table
+        /// </summary>
+        public override string Name { get { return _table.Name; } }
+
+        /// <summary>
+        /// Defines a non-default name of the entity table
+        /// </summary>
+        /// <param name="name">Name of the table file without extension</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> ToTable(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException("name");
+
+            _table.Name = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Resets all mappings
+        /// </summary>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> Reset()
+        {
+            Clear();
+            return this;
+        }
+
+        /// <summary>
+        /// Registers interceptor to control serialization of properties
+        /// </summary>
+        /// <param name="interceptor">Custom interceptor implementation</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> WithInterceptor(Interceptor<TInterface> interceptor)
+        {
+            if (interceptor == null)
+                throw new ArgumentNullException();
+
+            _table.Add(interceptor);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Registers interceptor function to control serialization of properties
+        /// </summary>
+        /// <param name="interceptor">Custom interceptor function</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> WithInterceptor(Func<TInterface, string, bool?> interceptor)
+        {
+            if (interceptor == null)
+                throw new ArgumentNullException();
+
+            _table.Add(new DelegateInterceptor<TInterface>(interceptor));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Defines primary key expression, indicating optional automatic generation of PK values
+        /// </summary>
+        /// <typeparam name="K">Type of the PK</typeparam>
+        /// <param name="keyBuilder">Primary key expression</param>
+        /// <param name="autoGen">Indicates automatic generation of PK values (int, long, Guid types only)</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> Key<TKey>(Expression<Func<TInterface, TKey>> keyBuilder, bool autoGen = false)
+        {
+            if (_key != null)
+                throw new InvalidOperationException("Key is already defined");
+
+            _table.Add(keyBuilder, _key = ExtractMember(keyBuilder, MemberUsage.KeyIndex), autoGen);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Defines complete mapping for public properties and fields via reflection, 
+        /// with specified primary key expression and optional automatic generation
+        /// </summary>
+        /// <typeparam name="K">Type of the PK</typeparam>
+        /// <param name="keyBuilder">Primary key expression</param>
+        /// <param name="autoGen">Indicates automatic generation of PK values (int, long, Guid types only)</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> Automap<K>(Expression<Func<TInterface, K>> keyBuilder, bool autoGen = false)
+        {
+            return Key(keyBuilder, autoGen).MapAll();
+        }
+
+        /// <summary>
+        /// Defines complete mapping for public properties and fields via reflection
+        /// </summary>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> MapAll()
+        {
+            var fields = from f in typeof(TInterface).GetPublicInstanceFields()
+                         where f != _key
+                         && !f.Attributes.HasFlag(FieldAttributes.InitOnly)
+                         && !f.IsDefined(typeof(XmlIgnoreAttribute), false)
+                         select f;
+
+            foreach (var f in fields)
+                _table.Add(new MemberMap<TInterface>(f));
+
+            var properties = from p in typeof(TInterface).GetPublicInstanceProperties()
+                             where p != _key
+                             && p.CanRead && p.CanWrite && p.GetGetMethod().IsPublic && p.GetSetMethod().IsPublic
+                             && !p.IsDefined(typeof(XmlIgnoreAttribute), false)
+                             select p;
+
+            foreach (var p in properties)
+                _table.Add(new MemberMap<TInterface>(p));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Removes mapping for specified member
+        /// </summary>
+        /// <typeparam name="K">Type of the member</typeparam>
+        /// <param name="property">Member access expression</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> Unmap<TKey>(Expression<Func<TInterface, TKey>> property)
+        {
+            var member = ExtractMember(property);
+            if (member == null)
+                throw new ArgumentException("Invalid member definition");
+
+            _table.Remove(member);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds mapping for specified member
+        /// </summary>
+        /// <typeparam name="K">Type of the member</typeparam>
+        /// <param name="property">Members access expression (public readable/writable property or field)</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> Map<TKey>(Expression<Func<TInterface, TKey>> property)
+        {
+            Expression target;
+            var member = ExtractMemberEx(property, out target);
+            if (member == null)
+                throw new ArgumentException("Invalid member definition");
+
+            _table.Add(new MemberMap<TInterface>(member, target, property.Parameters[0]));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds non-unique typed index over single component
+        /// </summary>
+        /// <typeparam name="TIndex1">Type of the index key</typeparam>
+        /// <param name="name">Name of the index</param>
+        /// <param name="indexBy">Indexing expression</param>
+        /// <param name="comparer">Optional comparer for indexing expression</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> WithIndex<TIndex1>(string name, Expression<Func<TInterface, TIndex1>> indexBy, IComparer<TIndex1> comparer = null)
+        {
+            CheckIndexDoesNotExists(name);
+
+            var member = ExtractMember(indexBy, MemberUsage.DataIndex);
+
+            _table.CreateIndex(name, indexBy.Compile(), member, comparer);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds non-unique typed index over two components
+        /// </summary>
+        /// <typeparam name="TIndex1">Type of the first index key component</typeparam>
+        /// <typeparam name="TIndex2">Type of the second index key component</typeparam>
+        /// <param name="name">Name of the index</param>
+        /// <param name="indexBy">First index key component expression</param>
+        /// <param name="thenBy">Second index key component expression</param>
+        /// <param name="comparerIndexBy">Optional comparer for first index key component</param>
+        /// <param name="comparerThenBy">Optional comparer for second index key component</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> WithIndex<TIndex1, TIndex2>(string name, Expression<Func<TInterface, TIndex1>> indexBy, Expression<Func<TInterface, TIndex2>> thenBy, IComparer<TIndex1> comparerIndexBy = null, IComparer<TIndex2> comparerThenBy = null)
+        {
+            CheckIndexDoesNotExists(name);
+
+            var member1 = ExtractMember(indexBy, MemberUsage.DataIndex);
+            var member2 = ExtractMember(thenBy, MemberUsage.DataIndex);
+
+            CheckUnique(member1, member2);
+
+            _table.CreateIndex<TIndex1, TIndex2>(name, member1, comparerIndexBy, member2, comparerThenBy);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds non-unique typed index over three components
+        /// </summary>
+        /// <typeparam name="TIndex1">Type of the first index key component</typeparam>
+        /// <typeparam name="TIndex2">Type of the second index key component</typeparam>
+        /// <typeparam name="TIndex3">Type of the third index key component</typeparam>
+        /// <param name="name">Name of the index</param>
+        /// <param name="indexBy">First index key component expression</param>
+        /// <param name="thenBy">Second index key component expression</param>
+        /// <param name="andThenBy">Third index key component expression</param>
+        /// <param name="comparerIndexBy">Optional comparer for first index key component</param>
+        /// <param name="comparerThenBy">Optional comparer for second index key component</param>
+        /// <param name="comparerAndThenBy">Optional comparer for thirt index key component</param>
+        /// <returns>Entity type mapping to continue with</returns>
+        public InterfaceMap<TInterface, TType> WithIndex<TIndex1, TIndex2, TIndex3>(string name, Expression<Func<TInterface, TIndex1>> indexBy, Expression<Func<TInterface, TIndex2>> thenBy, Expression<Func<TInterface, TIndex3>> andThenBy, IComparer<TIndex1> comparerIndexBy = null, IComparer<TIndex2> comparerThenBy = null, IComparer<TIndex3> comparerAndThenBy = null)
+        {
+            CheckIndexDoesNotExists(name);
+
+            var member1 = ExtractMember(indexBy, MemberUsage.DataIndex);
+            var member2 = ExtractMember(thenBy, MemberUsage.DataIndex);
+            var member3 = ExtractMember(andThenBy, MemberUsage.DataIndex);
+
+            CheckUnique(member1, member2, member3);
+
+            _table.CreateIndex<TIndex1, TIndex2, TIndex3>(name, member1, comparerIndexBy, member2, comparerThenBy, member3, comparerAndThenBy);
+
+            return this;
+        }
+
+        static void CheckUnique(params MemberInfo[] members)
+        {
+            if (members.Distinct().Count() != members.Length)
+                throw new InvalidOperationException("Duplicate index members");
+        }
+
+        void CheckIndexDoesNotExists(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("name");
+
+            var index = _table.GetIndex(name);
+            if (index != null)
+                throw new InvalidOperationException(string.Format("Index name {0} is already defined", name));
+        }
+
+        enum MemberUsage
+        {
+            Serialization,
+            KeyIndex,
+            DataIndex
+        }
+
+        static MemberInfo ExtractMember<TKey>(Expression<Func<TInterface, TKey>> prop, MemberUsage usage = MemberUsage.Serialization)
+        {
+            Expression target;
+
+            var result = ExtractMemberEx(prop, out target, usage);
+
+            if (target != null)
+                throw new InvalidOperationException("Invalid member provided");
+
+            return result;
+        }
+
+        static MemberInfo ExtractMemberEx<TKey>(Expression<Func<TInterface, TKey>> prop, out Expression target, MemberUsage usage = MemberUsage.Serialization)
+        {
+            target = null;
+
+            var param = prop.Parameters[0];
+            var expr = prop.Body as MemberExpression;
+
+            if (expr == null)
+            {
+                if (usage == MemberUsage.KeyIndex) return null;
+
+                throw new ArgumentException("Cannot extract member information");
+            }
+
+            var member = expr.Member;
+
+            var fi = member as FieldInfo;
+            if (fi != null)
+            {
+                if (fi.IsInitOnly && usage != MemberUsage.DataIndex)
+                    throw new ArgumentException("Read only fields are not supported");
+
+                if (expr.Expression != param)
+                    target = expr.Expression;
+
+                return fi;
+            }
+
+            var pi = member as PropertyInfo;
+            if (pi != null)
+            {
+                if (!pi.CanRead)
+                    throw new ArgumentException("Property must be readable");
+
+                if (!pi.CanWrite && usage != MemberUsage.DataIndex)
+                    throw new ArgumentException("Property must be writable");
+
+                if (expr.Expression != param)
+                    target = expr.Expression;
+
+                return pi;
+            }
+
+            if (usage == MemberUsage.KeyIndex) // constant key
+                return null;
+
+            throw new ArgumentException("Cannot extract member information");
+        }
+
+        internal override DbTable Initialize(IDbTableStorage table)
+        {
+            var result = _table;
+            result.Initialize(table);
+            return result;
+        }
+
+        internal override Type KeyType
+        {
+            get { return _table.KeyIndex.KeyType; }
+        }
+    }
+}


### PR DESCRIPTION
It is often desirable to allow the persistence of a data contract (i.e.
an interface) rather than a specific object. This allows components in
higher layers of the architecture to natively supply instances for
persistence without the persistence layer needing to map into the
underlying persistent ttype.

Given Lex.Db's excellent mapping and persistence mechanisms, it was very
easy to allow this useage scenario through the provision of
InterfaceMap<TInterface,TType> -> DbTable<TInterface,TType> classes.
These classes are synonymous to the TypeMap<T> -> DbTable<T> but exposes
instances as a interfaces and uses the concrete TType (which must
implement TInterface) parameter merely for reading instances from the
store.

NOTES: InterfaceMap<TInterface,TType> copies large swathes of
TypeMap<T>. It would probably be possible to push a lot of the copied
code into a base class (TypeMapBase<T>?) to limit the duplication.

Tests for interface based persistence were copied from the existing
class based persistence and pass successfully.
