### PR TITLE
Allow WP8 version to specify the storage folder (similar to the WinRT)

### DIFF
--- a/Lex.Db/Db/DbInstance.cs
+++ b/Lex.Db/Db/DbInstance.cs
@@ -31,7 +31,7 @@ namespace Lex.Db
       _schema = Storage.OpenSchema(path, home);
     }
 
-#if NETFX_CORE
+#if NETFX_CORE || WINDOWS_PHONE
     /// <summary>
     /// Creates database instance with specified path
     /// </summary>

--- a/Lex.Db/Storage/DbStorage.cs
+++ b/Lex.Db/Storage/DbStorage.cs
@@ -17,7 +17,7 @@ namespace Lex.Db
       path = Path.Combine("Lex.Db", path);
       var root = home as string;
 
-#if NETFX_CORE 
+#if NETFX_CORE || WINDOWS_PHONE
       if (root == null) 
       {
         var folder = home as Windows.Storage.StorageFolder;
@@ -28,8 +28,6 @@ namespace Lex.Db
       }
 
       return new FileSystem.DbSchemaStorage(Path.Combine(root, path));
-#elif WINDOWS_PHONE
-      return new IsolatedStorage.DbSchemaStorage(_storage, path);
 #elif SILVERLIGHT
       
       if (Application.Current.HasElevatedPermissions) 


### PR DESCRIPTION
I wanted to be able to deploy a database along with the xap (deployed relative to the installation folder).  These changes allow me to do this, and all tests pass (couldn't test was the universal project without the SDK).  Does this look reasonable?
