### PR TITLE
make portable for win81 & wp81

### DIFF
--- a/Lex.Db.Tests/WinRT81/Lex.Db.Tests.WinRT81.csproj
+++ b/Lex.Db.Tests/WinRT81/Lex.Db.Tests.WinRT81.csproj
@@ -82,9 +82,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Lex.Db\Lex.Db.WinRT81.csproj">
-      <Project>{7c063abd-5807-4076-99af-f7167afda82e}</Project>
-      <Name>Lex.Db.WinRT81</Name>
+    <ProjectReference Include="..\..\Lex.Db\Lex.Db.Portable.csproj">
+      <Project>{f734d16c-a6e2-4748-9a21-ef774f788ecd}</Project>
+      <Name>Lex.Db.Portable</Name>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">

--- a/Lex.Db/Framework/OSFileStream.cs
+++ b/Lex.Db/Framework/OSFileStream.cs
@@ -699,11 +699,7 @@ namespace Lex.Db
       FILE_STANDARD_INFO info;
       unsafe
       {
-#if WINDOWS_APP || WINDOWS_PHONE_APP
         var infoSize = Marshal.SizeOf<FILE_STANDARD_INFO>();
-#else
-        var infoSize = Marshal.SizeOf(typeof(FILE_STANDARD_INFO));
-#endif
         var result = GetFileInformationByHandleEx(handle, FILE_INFO_BY_HANDLE_CLASS.FileStandardInfo, new IntPtr(&info), infoSize);
         fileSize = info.EndOfFile;
         return result;

--- a/Lex.Db/Lex.Db.Portable.csproj
+++ b/Lex.Db/Lex.Db.Portable.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F734D16C-A6E2-4748-9A21-EF774F788ECD}</ProjectGuid>
@@ -13,8 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile32</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <BaseIntermediateOutputPath>obj\portable</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -22,9 +22,10 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\bin\Debug\Portable\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETFX_CORE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\bin\Release\Portable\Lex.Db.xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Core\CtorOfT.cs" />
@@ -88,6 +90,8 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Storage\DbStorage.cs" />
+    <Compile Include="Storage\FileSystem\DbSchemaStorage.cs" />
+    <Compile Include="Storage\FileSystem\DbTableStorage.cs" />
     <Compile Include="Storage\Interfaces\IDbSchemaStorage.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -98,7 +102,10 @@
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <TargetPlatform Include="Windows, Version=8.1" />
+    <TargetPlatform Include="WindowsPhoneApp, Version=8.1" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Lex.Db/Storage/DbStorage.cs
+++ b/Lex.Db/Storage/DbStorage.cs
@@ -14,9 +14,6 @@ namespace Lex.Db
 #endif
     public IDbSchemaStorage OpenSchema(string path, object home)
     {
-#if PORTABLE
-      return null;
-#else
       path = Path.Combine("Lex.Db", path);
       var root = home as string;
 
@@ -29,7 +26,7 @@ namespace Lex.Db
         else
           root = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
       }
-
+      
       return new FileSystem.DbSchemaStorage(Path.Combine(root, path));
 #elif WINDOWS_PHONE
       return new IsolatedStorage.DbSchemaStorage(_storage, path);
@@ -49,7 +46,6 @@ namespace Lex.Db
         root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
       return new FileSystem.DbSchemaStorage(Path.Combine(root, path));
-#endif
 #endif
     }
 

--- a/NuGet/Lex.Db.1.2.1.0.nuspec
+++ b/NuGet/Lex.Db.1.2.1.0.nuspec
@@ -83,8 +83,8 @@ SortedSet supported.
         <file src="..\bin\Release\WinRT\Lex.Db.xml" target="lib\netcore45\Lex.Db.xml" />
         <file src="..\bin\Release\WinRT81\Lex.Db.dll" target="lib\netcore451\Lex.Db.dll" />
         <file src="..\bin\Release\WinRT81\Lex.Db.xml" target="lib\netcore451\Lex.Db.xml" />
-        <file src="..\bin\Release\Portable\Lex.Db.dll" target="lib\portable-net4+sl5+wp8+win8+wpa81\Lex.Db.dll" />
-        <file src="..\bin\Release\Portable\Lex.Db.xml" target="lib\portable-net4+sl5+wp8+win8+wpa81\Lex.Db.xml" />
+        <file src="..\bin\Release\Portable\Lex.Db.dll" target="lib\portable-win81+wpa81\Lex.Db.dll" />
+        <file src="..\bin\Release\Portable\Lex.Db.xml" target="lib\portable-win81+wpa81\Lex.Db.xml" />
         <file src="..\Lex.Db\Db\DbTableAsync.cs" target="lib\sl50\DbTableAsync.cs" />
         <file src="..\bin\Release\Silverlight5\Lex.Db.dll" target="lib\sl50\Lex.Db.dll" />
         <file src="..\bin\Release\Silverlight5\Lex.Db.xml" target="lib\sl50\Lex.Db.xml" />


### PR DESCRIPTION
at now, the portable lib is useless, since the io api isn't portable for .net4 & winrt & sl. i made the patch to let the portable lib work for winrt8.1 & wp8.1.