### PR TITLE
Added new project for portable library + .Net Core 1.0 support plus reflection fixes

### DIFF
--- a/Lex.Db.Libs.sln
+++ b/Lex.Db.Libs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Lex.Db.Shared", "lib\Lex.Db.Shared\Lex.Db.Shared.shproj", "{DAA436C4-AF4D-44A2-A387-2A80E56C7DA8}"
 EndProject
@@ -29,11 +29,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lex.Db.iOS", "lib\Lex.Db.iO
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lex.Db.Android", "lib\Lex.Db.Android\Lex.Db.Android.csproj", "{D6DD941D-5C15-4CE5-9BF3-69875F138420}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lex.Db.Portable.Core", "lib\Lex.Db.Portable.Core\Lex.Db.Portable.Core.csproj", "{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{360e79ea-6118-47a6-9f00-fa8ecfca3338}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{127859d4-7ad4-4d34-83bd-b24f8709b54f}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{d6dd941d-5c15-4ce5-9bf3-69875f138420}*SharedItemsImports = 4
+		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{f362f6b0-90b4-449b-96f8-8c5d7e950c2d}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{f362f6b0-90b4-449b-96f8-8c5d7e950c2c}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{a18b7c13-c346-4f1e-aad0-90acd85cea8a}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{5bbc2755-3c7f-4847-bfbf-6b415cc4bdda}*SharedItemsImports = 4
@@ -230,6 +233,22 @@ Global
 		{D6DD941D-5C15-4CE5-9BF3-69875F138420}.Release|x64.Build.0 = Release|Any CPU
 		{D6DD941D-5C15-4CE5-9BF3-69875F138420}.Release|x86.ActiveCfg = Release|Any CPU
 		{D6DD941D-5C15-4CE5-9BF3-69875F138420}.Release|x86.Build.0 = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|x64.Build.0 = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|x86.Build.0 = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|ARM.Build.0 = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|x64.ActiveCfg = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|x64.Build.0 = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|x86.ActiveCfg = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -247,5 +266,6 @@ Global
 		{F362F6B0-90B4-449B-96F8-8C5D7E950C2C} = {F3C297C0-4BA8-4CAE-AD27-2A6DFABF37F0}
 		{64F35568-C748-4EE2-BE6A-B8190F593857} = {F3C297C0-4BA8-4CAE-AD27-2A6DFABF37F0}
 		{D6DD941D-5C15-4CE5-9BF3-69875F138420} = {F3C297C0-4BA8-4CAE-AD27-2A6DFABF37F0}
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D} = {F3C297C0-4BA8-4CAE-AD27-2A6DFABF37F0}
 	EndGlobalSection
 EndGlobal

--- a/Lex.Db.sln
+++ b/Lex.Db.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Lex.Db.Shared", "lib\Lex.Db.Shared\Lex.Db.Shared.shproj", "{DAA436C4-AF4D-44A2-A387-2A80E56C7DA8}"
 EndProject
@@ -59,6 +59,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lex.Db.Sample2", "samples\L
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lex.Db.Tests.WP8", "tests\Lex.Db.Tests.WP8\Lex.Db.Tests.WP8.csproj", "{CB60506B-B9E7-4E39-87BC-F8F4B2F6DA8C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lex.Db.Portable.Core", "lib\Lex.Db.Portable.Core\Lex.Db.Portable.Core.csproj", "{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tests\Lex.Db.Tests.Shared\Lex.Db.Tests.Shared.projitems*{cb60506b-b9e7-4e39-87bc-f8f4b2f6da8c}*SharedItemsImports = 4
@@ -67,6 +69,7 @@ Global
 		tests\Lex.Db.Tests.Shared\Lex.Db.Tests.Shared.projitems*{57fe6afa-c932-47c2-9761-2592ccf3cbe5}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{127859d4-7ad4-4d34-83bd-b24f8709b54f}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{d6dd941d-5c15-4ce5-9bf3-69875f138420}*SharedItemsImports = 4
+		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{f362f6b0-90b4-449b-96f8-8c5d7e950c2d}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{f362f6b0-90b4-449b-96f8-8c5d7e950c2c}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{a18b7c13-c346-4f1e-aad0-90acd85cea8a}*SharedItemsImports = 4
 		lib\Lex.Db.Shared\Lex.Db.Shared.projitems*{5bbc2755-3c7f-4847-bfbf-6b415cc4bdda}*SharedItemsImports = 4
@@ -511,6 +514,22 @@ Global
 		{CB60506B-B9E7-4E39-87BC-F8F4B2F6DA8C}.Release|x86.ActiveCfg = Release|x86
 		{CB60506B-B9E7-4E39-87BC-F8F4B2F6DA8C}.Release|x86.Build.0 = Release|x86
 		{CB60506B-B9E7-4E39-87BC-F8F4B2F6DA8C}.Release|x86.Deploy.0 = Release|x86
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|x64.Build.0 = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Debug|x86.Build.0 = Debug|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|ARM.Build.0 = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|x64.ActiveCfg = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|x64.Build.0 = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|x86.ActiveCfg = Release|Any CPU
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -541,5 +560,6 @@ Global
 		{46764D1E-CD8A-4BAA-8AFB-7A28EB9EF65D} = {EAAD171F-83C8-4C3D-AABE-9EBC7F87A569}
 		{1D91BAB8-FADB-4CBF-9ABA-A325470A2D8C} = {24897141-AF2F-4A49-9E34-651E27ECDF5B}
 		{CB60506B-B9E7-4E39-87BC-F8F4B2F6DA8C} = {EAAD171F-83C8-4C3D-AABE-9EBC7F87A569}
+		{F362F6B0-90B4-449B-96F8-8C5D7E950C2D} = {F3C297C0-4BA8-4CAE-AD27-2A6DFABF37F0}
 	EndGlobalSection
 EndGlobal

--- a/lib/Lex.Db.Portable.Core/Lex.Db.Portable.Core.csproj
+++ b/lib/Lex.Db.Portable.Core/Lex.Db.Portable.Core.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F362F6B0-90B4-449B-96F8-8C5D7E950C2D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Lex.Db</RootNamespace>
+    <AssemblyName>Lex.Db</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;PORTABLE CORE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Lex.Db.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="..\Lex.Db.Shared\Lex.Db.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/lib/Lex.Db.Portable.Core/Properties/AssemblyInfo.cs
+++ b/lib/Lex.Db.Portable.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("Lex.Db for .NET Portable")]
+
+

--- a/lib/Lex.Db.Shared/Core/TypeHelper.cs
+++ b/lib/Lex.Db.Shared/Core/TypeHelper.cs
@@ -460,5 +460,5 @@ namespace Lex.Db
       throw new NotSupportedException();
     }
 #endif
-    }
+  }
 }

--- a/lib/Lex.Db.Shared/Core/TypeHelper.cs
+++ b/lib/Lex.Db.Shared/Core/TypeHelper.cs
@@ -175,16 +175,16 @@ namespace Lex.Db
              where m.IsStatic
              select m;
 #elif CORE
-        List<MethodInfo> methodInfos = new List<MethodInfo>();
-        var methods = type.GetRuntimeMethods();
-        foreach (MethodInfo methodInfo in methods)
-        {
-            if (methodInfo.IsStatic)
-                methodInfos.Add(methodInfo);
-        }
-        return methodInfos;
+      List<MethodInfo> methodInfos = new List<MethodInfo>();
+      var methods = type.GetRuntimeMethods();
+      foreach (MethodInfo methodInfo in methods)
+      {
+          if (methodInfo.IsStatic)
+              methodInfos.Add(methodInfo);
+      }
+      return methodInfos;
 #else
-        return type.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+      return type.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
 #endif
     }
 
@@ -257,7 +257,7 @@ namespace Lex.Db
 #else
       return type.GetMethod(name, BindingFlags.Static | BindingFlags.Public);
 #endif
-        }
+    }
 
     public static MethodInfo GetPublicInstanceMethod(this Type type, string name)
     {

--- a/lib/Lex.Db.Shared/Db/DbInstance.cs
+++ b/lib/Lex.Db.Shared/Db/DbInstance.cs
@@ -838,7 +838,7 @@ namespace Lex.Db
 #else
       var keyMethod = GetType().GetMethod("InitPKCore", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 #endif
-            var pkKeyMethod = keyMethod.MakeGenericMethod(pk);
+      var pkKeyMethod = keyMethod.MakeGenericMethod(pk);
 
       pkKeyMethod.Invoke(this, new object[] { table });
     }

--- a/lib/Lex.Db.Shared/Db/DbInstance.cs
+++ b/lib/Lex.Db.Shared/Db/DbInstance.cs
@@ -833,10 +833,12 @@ namespace Lex.Db
     {
 #if NETFX_CORE
       var keyMethod = GetType().GetRuntimeMethod("InitPKCore", new Type[] { typeof(DbTable<object[]>) });
+#elif CORE
+      var keyMethod = GetType().GetMethod("InitPKCore", new Type[] { typeof(DbTable<object[]>) });
 #else
       var keyMethod = GetType().GetMethod("InitPKCore", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 #endif
-      var pkKeyMethod = keyMethod.MakeGenericMethod(pk);
+            var pkKeyMethod = keyMethod.MakeGenericMethod(pk);
 
       pkKeyMethod.Invoke(this, new object[] { table });
     }

--- a/lib/Lex.Db.Shared/Mapping/Metadata.cs
+++ b/lib/Lex.Db.Shared/Mapping/Metadata.cs
@@ -286,7 +286,7 @@ namespace Lex.Db.Mapping
       }
     }
 
-    #endregion
+        #endregion
 
     #region MakeWriteMethod logic
 
@@ -299,7 +299,7 @@ namespace Lex.Db.Mapping
       public Action<DataWriter, object> Writer;
     }
 #else
-    static readonly MethodInfo _writeShort = typeof(BinaryWriter).GetMethod("Write", new[] { typeof(short) });
+    static readonly MethodInfo _writeShort = TypeHelper.GetMethod(typeof(BinaryWriter), "Write", new[] { typeof(short) });
 #endif
 
     /// <summary>

--- a/lib/Lex.Db.Shared/Mapping/Metadata.cs
+++ b/lib/Lex.Db.Shared/Mapping/Metadata.cs
@@ -286,7 +286,7 @@ namespace Lex.Db.Mapping
       }
     }
 
-        #endregion
+    #endregion
 
     #region MakeWriteMethod logic
 
@@ -299,7 +299,7 @@ namespace Lex.Db.Mapping
       public Action<DataWriter, object> Writer;
     }
 #else
-    static readonly MethodInfo _writeShort = TypeHelper.GetMethod(typeof(BinaryWriter), "Write", new[] { typeof(short) });
+    static readonly MethodInfo _writeShort = typeof(BinaryWriter).GetMethod("Write", new[] { typeof(short) });
 #endif
 
     /// <summary>

--- a/lib/Lex.Db.Shared/Serialization/DbTypes.cs
+++ b/lib/Lex.Db.Shared/Serialization/DbTypes.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 
 namespace Lex.Db.Serialization
@@ -124,17 +125,30 @@ namespace Lex.Db.Serialization
 
     public static Type GetCollectionElementType(Type type)
     {
+#if CORE
+      return (from i in type.GetTypeInfo().ImplementedInterfaces
+          where i.IsGenericType() && i.GetGenericTypeDefinition() == typeof(ICollection<>)
+          select i.GenericTypeArguments[0]).FirstOrDefault();
+#else
       return (from i in type.GetInterfaces()
-              where i.IsGenericType() && i.GetGenericTypeDefinition() == typeof(ICollection<>)
-              select i.GetGenericArguments()[0]).FirstOrDefault();
+          where i.IsGenericType() && i.GetGenericTypeDefinition() == typeof(ICollection<>)
+          select i.GetGenericArguments()[0]).FirstOrDefault();
+#endif
     }
 
     public static Tuple<Type, Type> GetDictionaryElementTypes(Type type)
     {
+#if CORE
+      return (from i in type.GetTypeInfo().ImplementedInterfaces
+              where i.IsGenericType() && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+              let args = i.GenericTypeArguments
+              select Tuple.Create(args[0], args[1])).FirstOrDefault();
+#else
       return (from i in type.GetInterfaces()
               where i.IsGenericType() && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
               let args = i.GetGenericArguments()
               select Tuple.Create(args[0], args[1])).FirstOrDefault();
+#endif
     }
   }
 }

--- a/lib/Lex.Db.Shared/Serialization/Serializers.cs
+++ b/lib/Lex.Db.Shared/Serialization/Serializers.cs
@@ -953,7 +953,7 @@ namespace Lex.Db.Serialization
       return ReadBytes(ReadInt32());
     }
 
-#if SILVERLIGHT && !WINDOWS_PHONE || PORTABLE
+#if SILVERLIGHT && !WINDOWS_PHONE || PORTABLE && !CORE
     
     /// <summary>
     /// Reads Decimal value from stream


### PR DESCRIPTION
The .Net Core 1.0 target has some differences in the type reflection stuff that make it not compatible with other targets.  Also, you apparently can't have a .Net Core 1.0 and a Silverlight 5.0 target in the same portable library.  This addresses this by adding a new project Lex.Db.Portable.Core, plus some conditionals in the code for the different reflection calls.  It appears later versions of .Net Core might fix the reflection problems, or at least make it a little closer.  However, I think the Silverlight problem will not go away, which is sad for this Silverlight user.